### PR TITLE
Add 14-day dependency cooldown to Renovate config

### DIFF
--- a/packages/renovate-config/default.json
+++ b/packages/renovate-config/default.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
+  "minimumReleaseAge": "14 days",
   "labels": ["dependencies"],
   "reviewers": ["JaneJeon"],
   "fetchReleaseNotes": true,


### PR DESCRIPTION
Set minimumReleaseAge to 14 days to reduce supply chain security risks
by waiting for upstream registries to catch and pull malicious packages
before Renovate suggests updates.

https://claude.ai/code/session_013SUXYReQYcqQrXnmCjiTto